### PR TITLE
feat: 계정복구, 개인키, 공개키 추출 기능 추가

### DIFF
--- a/src/app/contentscript.js
+++ b/src/app/contentscript.js
@@ -23,7 +23,7 @@ function initialize() {
   console.warn('content script initialize');
 
   // post message를 받는 이벤트 리스너
-  window.addEventListener('message', function (event) {
+  window.addEventListener('message', (event) => {
     // We only accept messages from ourselves
     if (event.source !== window) return;
 

--- a/src/app/controller.js
+++ b/src/app/controller.js
@@ -1,8 +1,13 @@
+import KeyringController from './controllers/keyring-controller';
 import ExtensionStore from './lib/localstore';
 
 class Controller {
   constructor() {
     this.store = new ExtensionStore();
+
+    this.keyringController = new KeyringController({
+      store: this.store,
+    });
   }
 }
 

--- a/src/app/controllers/keyring-controller.js
+++ b/src/app/controllers/keyring-controller.js
@@ -1,14 +1,21 @@
 import encryptor from 'browser-passworder';
 
-import Controller from '../controller';
 import HdKeyring from '../lib/hd-keyring';
+import { normalize, stripHexPrefix } from '../lib/util';
+
+const bip39 = require('bip39');
+
+const KEYRINGS_TYPE_MAP = {
+  HD_KEYRING: 'HD Key Tree',
+  SIMPLE_KEYRING: 'Simple Key Pair',
+};
 
 class KeyringController {
-  constructor() {
+  constructor(opts = {}) {
     this.hdKeyring = new HdKeyring();
-    this.controller = new Controller();
     this.keyrings = [];
     this.password = '';
+    this.store = opts.store || {};
   }
 
   // 니모닉 생성
@@ -38,8 +45,41 @@ class KeyringController {
     return null;
   }
 
+  // 계정 복구
+  async createNewVaultAndRestore({ password, mnemonic }) {
+    // 니모닉 단어 리스트 검증
+    const wordlists = Object.values(bip39.wordlists);
+    if (
+      wordlists.every((wordlist) => !bip39.validateMnemonic(mnemonic, wordlist))
+    ) {
+      return Promise.reject(new Error('Seed phrase is invalid.'));
+    }
+
+    this.clearKeyrings();
+    await this.persistAllKeyrings(password);
+
+    // add new keyring
+    const keyring = new HdKeyring({
+      mnemonic,
+      numberOfAccounts: 1,
+    });
+
+    const accounts = await keyring.getAccounts();
+    this.checkForDuplicate(KEYRINGS_TYPE_MAP.HD_KEYRING, accounts);
+    if (!accounts.length)
+      throw new Error('KeyringController - First Account not found.');
+
+    this.keyrings.push(keyring);
+
+    const vault = await this.persistAllKeyrings(password);
+    return {
+      accounts,
+      vault,
+    };
+  }
+
   // 키링 배열을 직렬화하고 사용자가 입력한 password로 암호화하여 저장소에 저장
-  persistAllKeyrings(password = this.password) {
+  persistAllKeyrings(password) {
     if (typeof password !== 'string') {
       return Promise.reject(
         new Error('KeyringController - password is not a string'),
@@ -59,13 +99,125 @@ class KeyringController {
           },
         );
       }),
-    ).then((serializedKeyrings) => {
-      return encryptor.encrypt(this.password, serializedKeyrings);
-    });
-    // .then((encryptedString) => {
-    //   this.store.updateState({ vault: encryptedString });
-    //   return true;
+    )
+      .then((serializedKeyrings) => {
+        return encryptor.encrypt(this.password, serializedKeyrings);
+      })
+      .then((encryptedString) => {
+        return encryptedString;
+      });
+  }
+
+  // 키링 clear
+  async clearKeyrings() {
+    // clear keyrings from memory
+    this.keyrings = [];
+    // this.memStore.updateState({
+    //   keyrings: [],
     // });
+  }
+
+  async getAccounts() {
+    const keyrings = this.keyrings || [];
+    const addrs = await Promise.all(
+      keyrings.map((kr) => kr.getAccounts()),
+    ).then((keyringArrays) => {
+      return keyringArrays.reduce((res, arr) => {
+        return res.concat(arr);
+      }, []);
+    });
+    return addrs.map(normalize);
+  }
+
+  // 중복체크
+  checkForDuplicate(type, newAccountArray) {
+    return this.getAccounts().then((accounts) => {
+      switch (type) {
+        case KEYRINGS_TYPE_MAP.SIMPLE_KEYRING: {
+          const isIncluded = Boolean(
+            accounts.find(
+              (key) =>
+                key === newAccountArray[0] ||
+                key === stripHexPrefix(newAccountArray[0]),
+            ),
+          );
+          return isIncluded
+            ? Promise.reject(
+                new Error(
+                  "The account you're are trying to import is a duplicate",
+                ),
+              )
+            : Promise.resolve(newAccountArray);
+        }
+        default: {
+          return Promise.resolve(newAccountArray);
+        }
+      }
+    });
+  }
+
+  // 비밀번호 검증 (vault)
+  async verifyPassword(password) {
+    const { vault: encryptedVault } = await this.store.get('vault');
+    console.warn('vault => ', encryptedVault);
+    if (!encryptedVault) {
+      throw new Error('Cannot unlock without a previous vault.');
+    }
+    const verifyResult = await encryptor.decrypt(password, encryptedVault);
+    return verifyResult;
+  }
+
+  // 계정 PrivateKey / PublicKey 추출
+  async exportKey({ address, keyType }) {
+    try {
+      const keyring = await this.getKeyringForAccount(address);
+      return keyring.exportKey({
+        address: normalize(address),
+        keyType,
+      });
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  }
+
+  /**
+   * Get Keyring For Account
+   *
+   * Returns the currently initialized keyring that manages
+   * the specified `address` if one exists.
+   *
+   * @param {string} address - An account address.
+   * @returns {Promise<Keyring>} The keyring of the account, if it exists.
+   */
+  getKeyringForAccount(address) {
+    const hexed = normalize(address);
+
+    return Promise.all(
+      this.keyrings.map((keyring) => {
+        return Promise.all([keyring, keyring.getAccounts()]);
+      }),
+    ).then((candidates) => {
+      const winners = candidates.filter((candidate) => {
+        const accounts = candidate[1].map(normalize);
+        return accounts.includes(hexed);
+      });
+      if (winners && winners.length > 0) {
+        return winners[0][0];
+      }
+
+      // Adding more info to the error
+      let errorInfo = '';
+      if (!address) {
+        errorInfo = 'The address passed in is invalid/empty';
+      } else if (!candidates || !candidates.length) {
+        errorInfo = 'There are no keyrings';
+      } else if (!winners || !winners.length) {
+        errorInfo = 'There are keyrings, but none match the address';
+      }
+      throw new Error(
+        `No keyring found for the requested account. Error info: ${errorInfo}`,
+      );
+    });
   }
 }
 

--- a/src/app/inpage.js
+++ b/src/app/inpage.js
@@ -1,5 +1,5 @@
 // 웹 페이지상에서 백그라운드에 메세지 보내기 위한 window 객체안에 메소드 선언
-window.sendMessageBackground = function () {
+window.sendMessageBackground = () => {
   // postMessage 전송
   window.postMessage({ type: 'inpage', text: '받아라 백그라운드여' }, '*');
 };

--- a/src/app/lib/hd-keyring.js
+++ b/src/app/lib/hd-keyring.js
@@ -35,13 +35,8 @@ class HdKeyring extends SimpleKeyring {
     this.hdPath = opts.hdPath || hdPathString;
 
     if (opts.mnemonic) {
-      this.initFromMnemonic(opts.mnemonic);
+      this.initFromAccount(this.initFromMnemonic(opts.mnemonic));
     }
-
-    if (opts.numberOfAccounts) {
-      return this.addAccounts(opts.numberOfAccounts);
-    }
-
     return Promise.resolve([]);
   }
 

--- a/src/app/lib/util.js
+++ b/src/app/lib/util.js
@@ -78,6 +78,14 @@ const addHexPrefix = (str) => {
   return `0x${str}`;
 };
 
+// address 앞에 0x로 시작하면 2자리 자르기
+function stripHexPrefix(address) {
+  if (address.startsWith('0x')) {
+    return address.slice(2);
+  }
+  return address;
+}
+
 // 정규화
 function normalize(input) {
   if (!input) {
@@ -95,4 +103,4 @@ function normalize(input) {
   return addHexPrefix(input.toLowerCase());
 }
 
-export { getEnvironmentType, checkForError, normalize };
+export { getEnvironmentType, checkForError, normalize, stripHexPrefix };

--- a/src/app/messages.js
+++ b/src/app/messages.js
@@ -7,4 +7,7 @@ export const BackgroundMessages = {
   GENERATE_MNEMONIC_BG: 'generateMnemonic', // 니모닉 생성
   VALIDATE_MNEMONIC_BG: 'validateMnemonic', // 니모닉 검증
   NEW_ACCOUNT_BG: 'newAccount', // 새 계정 생성
+  IMPORT_ACCOUNT_BG: 'importAccount', // 계정 복구
+  EXPORT_PRIVATE_KEY_BG: 'exportPrivateKey', // 비공개키 추출
+  EXPORT_PUBLIC_KEY_BG: 'exportPublicKey', // 공개키 추출
 };

--- a/src/ui/data/account/account.api.js
+++ b/src/ui/data/account/account.api.js
@@ -26,3 +26,30 @@ export async function newAccount({ password, mnemonic }) {
   );
   return accounts;
 }
+
+// 계정 복구
+export async function importAccount({ password, mnemonic }) {
+  const accounts = await Messenger.sendMessageToBackground(
+    BackgroundMessages.IMPORT_ACCOUNT_BG,
+    { password, mnemonic },
+  );
+  return accounts;
+}
+
+// privateKey 추출
+export async function exportPrivateKey({ address, password }) {
+  const privateKey = await Messenger.sendMessageToBackground(
+    BackgroundMessages.EXPORT_PRIVATE_KEY_BG,
+    { address, password },
+  );
+  return privateKey;
+}
+
+// publicKey 추출
+export async function exportPublicKey({ address, password }) {
+  const publicKey = await Messenger.sendMessageToBackground(
+    BackgroundMessages.EXPORT_PUBLIC_KEY_BG,
+    { address, password },
+  );
+  return publicKey;
+}

--- a/src/ui/pages/home.jsx
+++ b/src/ui/pages/home.jsx
@@ -40,13 +40,24 @@ function Home() {
         Hong
       </Button>
       <Button
-        className="font-bold pl-5"
+        color={THEME_COLOR.INFO}
+        className="my-5"
         suffixIcon={<FaBeer />}
         onClick={() => {
-          navigation('/account');
+          navigation('/new-account');
         }}
       >
-        Account
+        New Account
+      </Button>
+      <Button
+        color={THEME_COLOR.SUCCESS}
+        className="my-5"
+        suffixIcon={<FaBeer />}
+        onClick={() => {
+          navigation('/import-account');
+        }}
+      >
+        Import Account
       </Button>
       <div>{bears}</div>
       <Button color={THEME_COLOR.WARNING} onClick={increasePopulation}>

--- a/src/ui/pages/import-account.jsx
+++ b/src/ui/pages/import-account.jsx
@@ -1,0 +1,80 @@
+import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from 'ui/components/atoms/button';
+import TextField from 'ui/components/atoms/text-field';
+import {
+  exportPrivateKey,
+  exportPublicKey,
+  importAccount,
+} from 'ui/data/account/account.api';
+
+function NewAccount() {
+  const [password, setPassword] = useState('');
+  const [accountsData, setAccountsData] = useState([]);
+  const [privateKey, setPrivateKey] = useState('');
+  const [publicKey, setPublicKey] = useState('');
+  const navigation = useNavigate();
+
+  const onNextPage = () => {
+    navigation('/');
+  };
+
+  // 계정 복구
+  const requestImportAccount = useCallback(async () => {
+    if (!password.length) alert('패스워드를 입력하세요');
+    const accounts = await importAccount({
+      mnemonic: document.getElementById('importMnemonicInput').value,
+      password,
+    });
+    setAccountsData(accounts);
+  }, [password]);
+
+  // 비공개키 추출
+  const requestExportPrivateKey = useCallback(async () => {
+    const privKey = await exportPrivateKey({
+      address: document.getElementById('address_text').value,
+      password,
+    });
+    setPrivateKey(privKey);
+  }, [password]);
+
+  // 공개키 추출
+  const requestExportPublicKey = useCallback(async () => {
+    const pubKey = await exportPublicKey({
+      address: document.getElementById('address_text').value,
+      password,
+    });
+    setPublicKey(pubKey);
+  }, [password]);
+
+  return (
+    <div style={{ padding: 16 }}>
+      <Button onClick={onNextPage}>Home</Button>
+      <br />
+
+      <div>니모닉 코드</div>
+      <textarea id="importMnemonicInput" style={{ width: '100%' }} />
+      <TextField
+        password
+        placeholder="새 비밀번호 입력"
+        model={password}
+        onChange={(e) => {
+          setPassword(e.target.value);
+        }}
+      />
+      <Button onClick={requestImportAccount}>계정 복구</Button>
+      <div>복구 계정 : {JSON.stringify(accountsData)}</div>
+
+      <br />
+      <TextField placeholder="주소값 입력" id="address_text" />
+      <Button onClick={requestExportPrivateKey}>privateKey 추출</Button>
+      <div className="break-words">비공개키 : {privateKey}</div>
+
+      <br />
+      <Button onClick={requestExportPublicKey}>publicKey 추출</Button>
+      <div className="break-words">공개키 : {publicKey}</div>
+    </div>
+  );
+}
+
+export default NewAccount;

--- a/src/ui/pages/new-account.jsx
+++ b/src/ui/pages/new-account.jsx
@@ -28,7 +28,7 @@ function NewAccount() {
   // 니모닉 검증
   const requestValidateMnemonic = async () => {
     const validate = await validateMnemonic(
-      document.getElementById('mnemonicInput').value,
+      document.getElementById('newMnemonicInput').value,
     );
     setMnemonicValidate(validate);
   };
@@ -51,7 +51,7 @@ function NewAccount() {
       <div>니모닉 코드 : {mnemonicSeed}</div>
       <br />
 
-      <textarea id="mnemonicInput" style={{ width: '100%' }} />
+      <textarea id="newMnemonicInput" style={{ width: '100%' }} />
       <Button onClick={requestValidateMnemonic}>니모닉 검증</Button>
       <div>니모닉 검증 결과 : {mnemonicValidate ? '정상' : ''}</div>
       <br />

--- a/src/ui/pages/routing.jsx
+++ b/src/ui/pages/routing.jsx
@@ -3,9 +3,10 @@ import { Route, Routes } from 'react-router-dom';
 import { APP_STAGE } from 'ui/constants/environment';
 
 import About from './about';
-import Account from './account';
 import Home from './home';
 import Hong from './hong';
+import ImportAccount from './import-account';
+import NewAccount from './new-account';
 import Provider from './provider';
 
 if (APP_STAGE === 'local') {
@@ -19,7 +20,8 @@ function Routing() {
       <Route path="/provider" element={<Provider />} />
       <Route path="/about" element={<About />} />
       <Route path="/hong" element={<Hong />} />
-      <Route path="/account" element={<Account />} />
+      <Route path="/new-account" element={<NewAccount />} />
+      <Route path="/import-account" element={<ImportAccount />} />
     </Routes>
   );
 }


### PR DESCRIPTION
### Short description

feat: 계정복구, 개인키, 공개키 추출 기능 추가

### Proposed changes

- 니모닉 통해서 wallet에서 address 추출
- 복구 시 입력한 비밀번호는 새 비밀번호 개념으로 암호화하여 vault 생성 후 store에 저장 (키 추출시 필요)
- address, password 값으로 해당 Wallet을 찾고 vault를 복호화하여 개인키, 공개키 추출

### How to test (Optional)

_How to test this PR_

### Screenshots (Optional)

#### Before this PR

#### After this PR

### Reference (Optional)
close #37-mnemonic

_resolves #issue-number_
_closes #issue-number_
_refs #issue-number_
