### PR TITLE
account 정보 store에 저장 기능 추가

### DIFF
--- a/src/app/background.js
+++ b/src/app/background.js
@@ -93,6 +93,18 @@ class Background {
       this.controller.importAccountStrategy,
     );
 
+    // store get accounts
+    this.requests.set(
+      BackgroundMessages.GET_STORE_ACCOUNTS,
+      this.controller.getStoreAccounts,
+    );
+
+    // store set selected address
+    this.requests.set(
+      BackgroundMessages.SET_STORE_SELECTED_ADDRESS,
+      this.controller.setStoreSelectedAddress,
+    );
+
     this.requests.set(
       BackgroundMessages.SEND_RAW_TRANSACTION,
       this.controller.sendRawTransaction,

--- a/src/app/controller.js
+++ b/src/app/controller.js
@@ -108,12 +108,25 @@ class Controller {
   };
 
   // 계정 가져오기 (비공개 키 or json 파일)
-  importAccountStrategy = async (_, { strategy, args }) => {
-    const selectedAddress = await this.keyringController.importAccountStrategy({
+  importAccountStrategy = (_, { strategy, args }) => {
+    const selectedAddress = this.keyringController.importAccountStrategy({
       strategy,
       args,
     });
     return selectedAddress;
+  };
+
+  // store get accounts
+  getStoreAccounts = async (_) => {
+    const accounts = await this.keyringController.getStoreAccounts();
+    return accounts;
+  };
+
+  // store set selected address
+  setStoreSelectedAddress = async (_, { selectedAddress }) => {
+    return Promise.resolve(
+      this.keyringController.updateStoreSelectedAddress(selectedAddress),
+    );
   };
 
   sendRawTransaction = async (_, { from, to, decimalValue }) => {

--- a/src/app/messages.js
+++ b/src/app/messages.js
@@ -13,5 +13,7 @@ export const BackgroundMessages = {
   EXPORT_PUBLIC_KEY_BG: 'exportPublicKey', // 공개키 추출
   EXPORT_KEYSTORE_V3_BG: 'exportKeystoreV3', // 키스토어 V3 추출
   IMPORT_ACCOUNT_STRATEGY_BG: 'importAccountStrategy', // 계정 가져오기(비공개키 or json 파일)
+  GET_STORE_ACCOUNTS: 'getStoreAccounts', // Store에서 Accounts 데이터 get
+  SET_STORE_SELECTED_ADDRESS: 'setStoreSelectedAddress', // Store에서 Accounts SelectedAddress 값 set
   SEND_RAW_TRANSACTION: 'sendRawTransaction',
 };

--- a/src/ui/data/account/account.api.js
+++ b/src/ui/data/account/account.api.js
@@ -71,3 +71,20 @@ export async function importAccountStrategy({ strategy, args }) {
   );
   return selectedAddress;
 }
+
+// store에서 accounts 정보 Get
+export async function getStoreAccounts() {
+  const accounts = await Messenger.sendMessageToBackground(
+    BackgroundMessages.GET_STORE_ACCOUNTS,
+  );
+  return accounts;
+}
+
+// store에서 accounts selectedAddress 정보 set
+export async function setStoreSelectedAddress(selectedAddress) {
+  const response = await Messenger.sendMessageToBackground(
+    BackgroundMessages.SET_STORE_SELECTED_ADDRESS,
+    { selectedAddress },
+  );
+  return response;
+}

--- a/src/ui/data/account/account.hooks.js
+++ b/src/ui/data/account/account.hooks.js
@@ -1,0 +1,21 @@
+import { useMutation, useQuery } from 'react-query';
+
+import { getStoreAccounts, setStoreSelectedAddress } from './account.api';
+
+export function useGetStoreAccounts(options) {
+  return useQuery(['/account/getStoreAccounts'], getStoreAccounts, {
+    retry: false,
+    ...options,
+  });
+}
+
+export function useSetStoreSelectedAddress(options) {
+  return useMutation(
+    ['/account/setStoreSelectedAddress'],
+    setStoreSelectedAddress,
+    {
+      retry: false,
+      ...options,
+    },
+  );
+}

--- a/src/ui/pages/home.jsx
+++ b/src/ui/pages/home.jsx
@@ -1,11 +1,32 @@
 import { FaBeer } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
 import Button from 'ui/components/atoms/button';
+import Card from 'ui/components/atoms/card';
 import Container from 'ui/components/atoms/container';
 import { THEME_COLOR } from 'ui/constants/colors';
+import {
+  useGetStoreAccounts,
+  useSetStoreSelectedAddress,
+} from 'ui/data/account/account.hooks';
 
 function Home() {
   const navigation = useNavigate();
+
+  // Store에서 정보 받아오기
+  const { data: accounts, refetch: updateAccounts } = useGetStoreAccounts();
+
+  // Store에 selectedAddress Update
+  const { mutate: updateSelectedAddress } = useSetStoreSelectedAddress({
+    onSuccess() {
+      updateAccounts();
+    },
+  });
+
+  // account change
+  const handleAccountChange = (event) => {
+    const { value: selectedAddress } = event.target;
+    updateSelectedAddress(selectedAddress);
+  };
 
   return (
     <Container className="p-4">
@@ -17,6 +38,26 @@ function Home() {
       >
         Provider
       </Button>
+
+      {accounts && (
+        <select
+          className="w-full"
+          name="accounts"
+          onChange={handleAccountChange}
+          value={accounts?.selectedAddress}
+        >
+          {accounts?.identities.map(({ address, name }, index) => (
+            <option key={index} value={address}>
+              {name}
+            </option>
+          ))}
+        </select>
+      )}
+
+      {accounts && (
+        <Card title="Selected Address" content={accounts.selectedAddress} />
+      )}
+
       <Button
         color={THEME_COLOR.INFO}
         className="my-5"

--- a/src/ui/pages/json-file.jsx
+++ b/src/ui/pages/json-file.jsx
@@ -97,7 +97,7 @@ function JsonFile() {
       </Button>
 
       <div>계정 가져오기 : {selectedAddress}</div>
-      <select name="providers" onChange={handleTypeChange} value={currentType}>
+      <select name="importType" onChange={handleTypeChange} value={currentType}>
         {importTypeList.map(({ type, name }, index) => (
           <option key={index} value={type}>
             {name}


### PR DESCRIPTION
### Short description

feat: account 정보 store에 저장 기능 추가

### Proposed changes

- 신규 계정 생성, 계정 가져오기, 비공개키 or JSON File import시 store에 accounts 키 값으로 계정 관련 정보 저장
- home.tsx에서 계정 정보 표시, select 박스로 계정 변경 시 selected address 값 update

### How to test (Optional)

_How to test this PR_

### Screenshots (Optional)

#### Before this PR

#### After this PR

### Reference (Optional)
close #48-account-save-store

_resolves #issue-number_
_closes #issue-number_
_refs #issue-number_
