### PR TITLE
account API 호출형태 변경, keystore to private key 추출 기능 추가

### DIFF
--- a/src/app/background.js
+++ b/src/app/background.js
@@ -45,16 +45,16 @@ class Background {
       this.controller.getCurrentChainId,
     );
 
-    // 니모닉 생성
+    // 신규 니모닉 얻기
     this.requests.set(
-      BackgroundMessages.GENERATE_MNEMONIC_BG,
-      this.controller.generateMnemonic,
+      BackgroundMessages.GET_NEW_MNEMONIC_BG,
+      this.controller.getNewMnemonic,
     );
 
     // 니모닉 검증
     this.requests.set(
-      BackgroundMessages.VALIDATE_MNEMONIC_BG,
-      this.controller.validateMnemonic,
+      BackgroundMessages.GET_MNEMONIC_VALIDATE_BG,
+      this.controller.getMnemonicValidate,
     );
 
     // 신규 계정 생성
@@ -71,26 +71,32 @@ class Background {
 
     // 비공개키 추출
     this.requests.set(
-      BackgroundMessages.EXPORT_PRIVATE_KEY_BG,
-      this.controller.exportPrivateKey,
+      BackgroundMessages.GET_EXPORT_PRIVATE_KEY_BG,
+      this.controller.getExportPrivateKey,
     );
 
     // 공개키 추출
     this.requests.set(
-      BackgroundMessages.EXPORT_PUBLIC_KEY_BG,
-      this.controller.exportPublicKey,
+      BackgroundMessages.GET_EXPORT_PUBLIC_KEY_BG,
+      this.controller.getExportPublicKey,
     );
 
     // 키스토어 v3 추출
     this.requests.set(
-      BackgroundMessages.EXPORT_KEYSTORE_V3_BG,
-      this.controller.exportKeystoreV3,
+      BackgroundMessages.GET_EXPORT_KEYSTORE_V3_BG,
+      this.controller.getExportKeystoreV3,
     );
 
     // 계정 가져오기 (비공개 키 or json 파일)
     this.requests.set(
-      BackgroundMessages.IMPORT_ACCOUNT_STRATEGY_BG,
-      this.controller.importAccountStrategy,
+      BackgroundMessages.GET_IMPORT_ACCOUNT_STRATEGY_BG,
+      this.controller.getImportAccountStrategy,
+    );
+
+    // keystore -> privKey 추출
+    this.requests.set(
+      BackgroundMessages.GET_KEYSTORE_TO_PRIVKEY,
+      this.controller.getKeystoreToPrivKey,
     );
 
     // store get accounts

--- a/src/app/controller.js
+++ b/src/app/controller.js
@@ -104,14 +104,16 @@ class Controller extends EventEmitter {
     };
   };
 
-  // 니모닉 구문 생성
-  generateMnemonic = async () => {
-    return Promise.resolve(this.keyringController.generateMnemonic());
+  // 신규 니모닉 구문 얻기
+  getNewMnemonic = async () => {
+    return Promise.resolve(this.keyringController.getNewMnemonic());
   };
 
   // 니모닉 코드 검증
-  validateMnemonic = async (_, { mnemonic }) => {
-    return Promise.resolve(this.keyringController.validateMnemonic(mnemonic));
+  getMnemonicValidate = async (_, { mnemonic }) => {
+    return Promise.resolve(
+      this.keyringController.getMnemonicValidate(mnemonic),
+    );
   };
 
   // 신규 계정 생성
@@ -133,10 +135,10 @@ class Controller extends EventEmitter {
   };
 
   // 비공개키 추출
-  exportPrivateKey = async (_, { address, password }) => {
+  getExportPrivateKey = async (_, { address, password }) => {
     // 비밀번호 검증
     await this.keyringController.verifyPassword(password);
-    const privateKey = await this.keyringController.exportKey({
+    const privateKey = await this.keyringController.getExportKey({
       keyType: 'private',
       address,
     });
@@ -144,10 +146,10 @@ class Controller extends EventEmitter {
   };
 
   // 공개키 추출
-  exportPublicKey = async (_, { address, password }) => {
+  getExportPublicKey = async (_, { address, password }) => {
     // 비밀번호 검증
     await this.keyringController.verifyPassword(password);
-    const publicKey = await this.keyringController.exportKey({
+    const publicKey = await this.keyringController.getExportKey({
       keyType: 'public',
       address,
     });
@@ -155,8 +157,8 @@ class Controller extends EventEmitter {
   };
 
   // 키스토어 v3 추출
-  exportKeystoreV3 = async (_, { privateKey, password }) => {
-    const keystoreV3 = await this.keyringController.exportKeystoreV3({
+  getExportKeystoreV3 = async (_, { privateKey, password }) => {
+    const keystoreV3 = await this.keyringController.getExportKeystoreV3({
       privateKey,
       password,
     });
@@ -164,12 +166,21 @@ class Controller extends EventEmitter {
   };
 
   // 계정 가져오기 (비공개 키 or json 파일)
-  importAccountStrategy = (_, { strategy, args }) => {
-    const selectedAddress = this.keyringController.importAccountStrategy({
+  getImportAccountStrategy = (_, { strategy, args }) => {
+    const selectedAddress = this.keyringController.getImportAccountStrategy({
       strategy,
       args,
     });
     return selectedAddress;
+  };
+
+  // keystore -> privKey 추출
+  getKeystoreToPrivKey = async (_, { fileContents, password }) => {
+    const privKey = await this.keyringController.getKeystoreToPrivKey({
+      fileContents,
+      password,
+    });
+    return { privKey };
   };
 
   // store get accounts

--- a/src/app/controllers/keyring-controller.js
+++ b/src/app/controllers/keyring-controller.js
@@ -49,15 +49,15 @@ class KeyringController {
     this.#setKeyringConfig({ vault });
   }
 
-  // 니모닉 생성
-  async generateMnemonic() {
+  // 신규 니모닉 얻기
+  async getNewMnemonic() {
     this.hdKeyring = new HdKeyring();
     const mnemonic = await this.hdKeyring.generateRandomMnemonic();
     return mnemonic;
   }
 
   // 니모닉 검증
-  validateMnemonic(mnemonic) {
+  getMnemonicValidate(mnemonic) {
     this.hdKeyring = new HdKeyring();
     const validate = this.hdKeyring.validateMnemonic(mnemonic);
     return validate;
@@ -197,7 +197,7 @@ class KeyringController {
   }
 
   // 계정 PrivateKey / PublicKey 추출
-  async exportKey({ address, keyType }) {
+  async getExportKey({ address, keyType }) {
     try {
       const keyring = await this.getKeyringForAccount(address);
       return keyring.exportKey({
@@ -207,6 +207,16 @@ class KeyringController {
     } catch (e) {
       return Promise.reject(e);
     }
+  }
+
+  // keystore json -> private key 추출
+  async getKeystoreToPrivKey({ fileContents, password }) {
+    this.#password = password;
+    const privateKey = await accountImporter.importAccount('JSON File', {
+      fileContents,
+      password,
+    });
+    return privateKey;
   }
 
   /**
@@ -253,7 +263,7 @@ class KeyringController {
    * @param {string} password 사용자 패스워드
    * @returns {Object} keystore v3 JSON
    */
-  async exportKeystoreV3({ privateKey, password }) {
+  async getExportKeystoreV3({ privateKey, password }) {
     const { rpcUrl } = await this.keyringConfig;
     const web3Query = new Web3Query(rpcUrl);
     return web3Query.getAccountsEncrypt({ privateKey, password });
@@ -265,7 +275,7 @@ class KeyringController {
    * @param {Object} args - { password: 비밀번호, privateKey || fileContents: 타입에 따라 비공개 키 or JSON File }
    * @returns {string} accounts[0] - 계정 address 주소
    */
-  async importAccountStrategy({ strategy, args }) {
+  async getImportAccountStrategy({ strategy, args }) {
     this.#password = args.password;
     const privateKey = await accountImporter.importAccount(strategy, args);
 

--- a/src/app/controllers/keyring-controller.test.js
+++ b/src/app/controllers/keyring-controller.test.js
@@ -30,12 +30,12 @@ describe('KeyringController', () => {
   });
 
   // Mnemonic generate and validate
-  describe('Generate Mnemonic', () => {
+  describe('Get New Mnemonic', () => {
     it('make new mnemonic seed and must be a valid seed syntax', async () => {
       let validate = false;
-      newMnemonic = await keyringController.generateMnemonic();
+      newMnemonic = await keyringController.getNewMnemonic();
       if (newMnemonic) {
-        validate = await keyringController.validateMnemonic(newMnemonic);
+        validate = await keyringController.getMnemonicValidate(newMnemonic);
       }
       expect(validate).toEqual(true);
     });
@@ -77,7 +77,7 @@ describe('KeyringController', () => {
     });
 
     it('Private key must be extracted with address value and password value', async () => {
-      const accountPrivateKey = await keyringController.exportKey({
+      const accountPrivateKey = await keyringController.getExportKey({
         keyType: 'private',
         address: defaultKeyringConfig.address,
       });
@@ -97,7 +97,7 @@ describe('KeyringController', () => {
     });
 
     it('Public key must be extracted with address value and password value', async () => {
-      const accountPublicKey = await keyringController.exportKey({
+      const accountPublicKey = await keyringController.getExportKey({
         keyType: 'public',
         address: defaultKeyringConfig.address,
       });
@@ -110,7 +110,7 @@ describe('KeyringController', () => {
   // account import for private key
   describe('importAccountWithStrategy', () => {
     beforeEach(async () => {
-      await keyringController.importAccountStrategy({
+      await keyringController.getImportAccountStrategy({
         strategy: 'Private Key',
         args: {
           password: defaultKeyringConfig.password,

--- a/src/app/messages.js
+++ b/src/app/messages.js
@@ -5,14 +5,15 @@ export const BackgroundMessages = {
   SET_RPC_TARGET: 'setRpcTarget',
   SET_PROVIDER_TYPE: 'setProviderType',
   GET_CURRENT_CHAIN_ID: 'getCurrentChainId',
-  GENERATE_MNEMONIC_BG: 'generateMnemonic', // 니모닉 생성
-  VALIDATE_MNEMONIC_BG: 'validateMnemonic', // 니모닉 검증
+  GET_NEW_MNEMONIC_BG: 'getNewMnemonic', // 신규 니모닉 얻기
+  GET_MNEMONIC_VALIDATE_BG: 'getMnemonicValidate', // 니모닉 검증값 얻기
   NEW_ACCOUNT_BG: 'newAccount', // 새 계정 생성
   IMPORT_ACCOUNT_BG: 'importAccount', // 계정 복구
-  EXPORT_PRIVATE_KEY_BG: 'exportPrivateKey', // 비공개키 추출
-  EXPORT_PUBLIC_KEY_BG: 'exportPublicKey', // 공개키 추출
-  EXPORT_KEYSTORE_V3_BG: 'exportKeystoreV3', // 키스토어 V3 추출
-  IMPORT_ACCOUNT_STRATEGY_BG: 'importAccountStrategy', // 계정 가져오기(비공개키 or json 파일)
+  GET_EXPORT_PRIVATE_KEY_BG: 'getExportPrivateKey', // 비공개키 추출
+  GET_EXPORT_PUBLIC_KEY_BG: 'getExportPublicKey', // 공개키 추출
+  GET_EXPORT_KEYSTORE_V3_BG: 'getExportKeystoreV3', // 키스토어 V3 추출
+  GET_IMPORT_ACCOUNT_STRATEGY_BG: 'getImportAccountStrategy', // 계정 가져오기(비공개키 or json 파일)
+  GET_KEYSTORE_TO_PRIVKEY: 'getKeystoreToPrivKey', // keystoreV3로부터 privateKey 추출
   GET_STORE_ACCOUNTS: 'getStoreAccounts', // Store에서 Accounts 데이터 get
   SET_STORE_SELECTED_ADDRESS: 'setStoreSelectedAddress', // Store에서 Accounts SelectedAddress 값 set
   SEND_RAW_TRANSACTION: 'sendRawTransaction',

--- a/src/ui/data/account/account.api.js
+++ b/src/ui/data/account/account.api.js
@@ -1,72 +1,76 @@
 import { BackgroundMessages } from 'app/messages';
 import Messenger from 'app/messenger';
 
-// 니모닉 생성
-export async function generateMnemonic() {
+// 신규 니모닉 얻기
+export async function getNewMnemonic() {
   const mnemonic = await Messenger.sendMessageToBackground(
-    BackgroundMessages.GENERATE_MNEMONIC_BG,
+    BackgroundMessages.GET_NEW_MNEMONIC_BG,
   );
   return mnemonic;
 }
 
 // 니모닉 검증
-export async function validateMnemonic(mnemonic) {
+export async function getMnemonicValidate(mnemonic) {
   const validate = await Messenger.sendMessageToBackground(
-    BackgroundMessages.VALIDATE_MNEMONIC_BG,
+    BackgroundMessages.GET_MNEMONIC_VALIDATE_BG,
     { mnemonic },
   );
   return validate;
 }
 
 // 신규 계정 생성
-export async function newAccount({ password, mnemonic }) {
+export async function newAccount({ mnemonic, password }) {
   const accounts = await Messenger.sendMessageToBackground(
     BackgroundMessages.NEW_ACCOUNT_BG,
-    { password, mnemonic },
+    { mnemonic, password },
   );
   return accounts;
 }
 
 // 계정 복구
-export async function importAccount({ password, mnemonic }) {
+export async function importAccount({ mnemonic, password }) {
   const accounts = await Messenger.sendMessageToBackground(
     BackgroundMessages.IMPORT_ACCOUNT_BG,
-    { password, mnemonic },
+    { mnemonic, password },
   );
   return accounts;
 }
 
 // privateKey 추출
-export async function exportPrivateKey({ address, password }) {
+export async function getExportPrivateKey({ address, password }) {
   const privateKey = await Messenger.sendMessageToBackground(
-    BackgroundMessages.EXPORT_PRIVATE_KEY_BG,
+    BackgroundMessages.GET_EXPORT_PRIVATE_KEY_BG,
     { address, password },
   );
   return privateKey;
 }
 
 // publicKey 추출
-export async function exportPublicKey({ address, password }) {
+export async function getExportPublicKey({ address, password }) {
   const publicKey = await Messenger.sendMessageToBackground(
-    BackgroundMessages.EXPORT_PUBLIC_KEY_BG,
+    BackgroundMessages.GET_EXPORT_PUBLIC_KEY_BG,
     { address, password },
   );
   return publicKey;
 }
 
 // keystore v3 추출
-export async function exportKeystoreV3({ privateKey, password }) {
+export async function getExportKeystoreV3({ privateKey, password }) {
   const keystoreV3 = await Messenger.sendMessageToBackground(
-    BackgroundMessages.EXPORT_KEYSTORE_V3_BG,
+    BackgroundMessages.GET_EXPORT_KEYSTORE_V3_BG,
     { privateKey, password },
   );
   return keystoreV3;
 }
 
-// 계정 가져오기 (privKey, json 파일) - v3
-export async function importAccountStrategy({ strategy, args }) {
+/**
+ * 비공개키 / keystore.json으로 주소값 뽑기
+ * @param {string} strategy - import 유형 (Private Key, JSON File)
+ * @param {object} args - { password: 비밀번호, privateKey || fileContents: 타입에 따라 비공개 키 or JSON File }
+ */
+export async function getImportAccountStrategy({ strategy, args }) {
   const selectedAddress = await Messenger.sendMessageToBackground(
-    BackgroundMessages.IMPORT_ACCOUNT_STRATEGY_BG,
+    BackgroundMessages.GET_IMPORT_ACCOUNT_STRATEGY_BG,
     { strategy, args },
   );
   return selectedAddress;
@@ -87,4 +91,13 @@ export async function setStoreSelectedAddress(selectedAddress) {
     { selectedAddress },
   );
   return response;
+}
+
+// keystore json 파일 -> private key 추출
+export async function getKeystoreToPrivKey({ fileContents, password }) {
+  const privKey = await Messenger.sendMessageToBackground(
+    BackgroundMessages.GET_KEYSTORE_TO_PRIVKEY,
+    { fileContents, password },
+  );
+  return privKey;
 }

--- a/src/ui/data/account/account.hooks.js
+++ b/src/ui/data/account/account.hooks.js
@@ -1,7 +1,114 @@
 import { useMutation, useQuery } from 'react-query';
 
-import { getStoreAccounts, setStoreSelectedAddress } from './account.api';
+import {
+  getExportKeystoreV3,
+  getExportPrivateKey,
+  getExportPublicKey,
+  getImportAccountStrategy,
+  getKeystoreToPrivKey,
+  getMnemonicValidate,
+  getNewMnemonic,
+  getStoreAccounts,
+  importAccount,
+  newAccount,
+  setStoreSelectedAddress,
+} from './account.api';
 
+// 신규 니모닉 얻기
+export function useGetNewMnemonic(options) {
+  return useQuery(['/account/getNewMnemonic'], getNewMnemonic, {
+    retry: false,
+    enabled: false,
+    ...options,
+  });
+}
+
+// 니모닉 검증 결과 얻기
+export function useGetMnemonicValidate({ mnemonic }, options) {
+  return useQuery(
+    ['/account/getMnemonicValidate', mnemonic],
+    () => getMnemonicValidate(mnemonic),
+    {
+      retry: false,
+      enabled: false,
+      ...options,
+    },
+  );
+}
+
+// 신규 계정 생성
+export function useNewAccount(options) {
+  return useMutation(['/account/newAccount'], newAccount, {
+    retry: false,
+    ...options,
+  });
+}
+
+// 계정 복구
+export function useImportAccount(options) {
+  return useMutation(['/account/importAccount'], importAccount, {
+    retry: false,
+    ...options,
+  });
+}
+
+// 개인키 추출
+export function useGetExportPrivateKey({ address, password }, options) {
+  return useQuery(
+    ['/account/getExportPrivateKey', { address, password }],
+    () => getExportPrivateKey({ address, password }),
+    {
+      retry: false,
+      enabled: false,
+      ...options,
+    },
+  );
+}
+
+// 공개키 추출
+export function useGetExportPublicKey({ address, password }, options) {
+  return useQuery(
+    ['/account/getExportPublicKey', { address, password }],
+    () => getExportPublicKey({ address, password }),
+    {
+      retry: false,
+      enabled: false,
+      ...options,
+    },
+  );
+}
+
+// keystore.json 추출(V3)
+export function useGetExportKeystoreV3({ privateKey, password }, options) {
+  return useQuery(
+    ['/account/getExportKeystoreV3', { privateKey, password }],
+    () => getExportKeystoreV3({ privateKey, password }),
+    {
+      retry: false,
+      enabled: false,
+      ...options,
+    },
+  );
+}
+
+/**
+ * 비공개키 / keystore.json으로 주소값 뽑기
+ * @param {string} strategy - import 유형 (Private Key, JSON File)
+ * @param {object} args - { password: 비밀번호, privateKey || fileContents: 타입에 따라 비공개 키 or JSON File }
+ */
+export function useGetImportAccountStrategy({ strategy, args }, options) {
+  return useQuery(
+    ['/account/getImportAccountStrategy', { strategy, args }],
+    () => getImportAccountStrategy({ strategy, args }),
+    {
+      retry: false,
+      enabled: false,
+      ...options,
+    },
+  );
+}
+
+// store에 저장된 계정 리스트 얻기
 export function useGetStoreAccounts(options) {
   return useQuery(['/account/getStoreAccounts'], getStoreAccounts, {
     retry: false,
@@ -9,12 +116,25 @@ export function useGetStoreAccounts(options) {
   });
 }
 
+// store에 selectedAddress update
 export function useSetStoreSelectedAddress(options) {
   return useMutation(
     ['/account/setStoreSelectedAddress'],
     setStoreSelectedAddress,
     {
       retry: false,
+      ...options,
+    },
+  );
+}
+
+// keystore.json으로 비공개키 추출
+export function useGetKeystoreToPrivKey({ fileContents, password }, options) {
+  return useQuery(
+    ['/account/getKeystoreToPrivKey', { fileContents, password }],
+    () => getKeystoreToPrivKey({ fileContents, password }),
+    {
+      enabled: false,
       ...options,
     },
   );

--- a/src/ui/pages/import-account.jsx
+++ b/src/ui/pages/import-account.jsx
@@ -1,77 +1,148 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import FileInput from 'react-simple-file-input';
 import Button from 'ui/components/atoms/button';
+import Card from 'ui/components/atoms/card';
 import TextField from 'ui/components/atoms/text-field';
+import { THEME_COLOR } from 'ui/constants/colors';
 import {
-  exportPrivateKey,
-  exportPublicKey,
-  importAccount,
-} from 'ui/data/account/account.api';
+  useGetExportPrivateKey,
+  useGetExportPublicKey,
+  useGetKeystoreToPrivKey,
+  useImportAccount,
+} from 'ui/data/account/account.hooks';
 
 function NewAccount() {
-  const [password, setPassword] = useState('');
-  const [accountsData, setAccountsData] = useState([]);
-  const [privateKey, setPrivateKey] = useState('');
-  const [publicKey, setPublicKey] = useState('');
   const navigation = useNavigate();
+  const [recoverySeed, setRecoverySeed] = useState(''); // 복구 구문 textarae
+  const [recoveryPassword, setRecoveryPassword] = useState(''); // 복구 재설정 패스워드
+
+  const [addressToPrivPub, setAddressToPrivPub] = useState(''); // 비공개/공개키 추출위한 address
+  const [passwordToPrivPub, setPasswordToPrivPub] = useState(''); // 비공개/공개키 추출위한 패스워드
+
+  const [keystoreInput, setKeystoreInput] = useState(''); // keystore file 정보
+  const [keystorePassword, setKeystorePassword] = useState(''); // keystore file 패스워드
+
+  // 계정 복구
+  const { data: recoveryAccount, mutate: mutateRecoveryAccount } =
+    useImportAccount();
+
+  // 비공개 추출
+  const { data: exportPrivKey, refetch: refetchExportPrivKey } =
+    useGetExportPrivateKey({
+      address: addressToPrivPub,
+      password: passwordToPrivPub,
+    });
+
+  // 공개키 추출
+  const { data: exportPubKey, refetch: refetchExportPubKey } =
+    useGetExportPublicKey({
+      address: addressToPrivPub,
+      password: passwordToPrivPub,
+    });
+
+  // keystore.json(V3) -> privateKey 추출
+  const { data: keystoreToPrivKey, refetch: refetchKeystoreToPrivKey } =
+    useGetKeystoreToPrivKey({
+      fileContents: keystoreInput,
+      password: keystorePassword,
+    });
+
+  const handleRecoveryAccount = () => {
+    mutateRecoveryAccount({
+      mnemonic: recoverySeed,
+      password: recoveryPassword,
+    });
+  };
 
   const onNextPage = () => {
     navigation('/');
   };
 
-  // 계정 복구
-  const requestImportAccount = useCallback(async () => {
-    if (!password.length) alert('패스워드를 입력하세요');
-    const accounts = await importAccount({
-      mnemonic: document.getElementById('importMnemonicInput').value,
-      password,
-    });
-    setAccountsData(accounts);
-  }, [password]);
-
-  // 비공개키 추출
-  const requestExportPrivateKey = useCallback(async () => {
-    const privKey = await exportPrivateKey({
-      address: document.getElementById('address_text').value,
-      password,
-    });
-    setPrivateKey(privKey);
-  }, [password]);
-
-  // 공개키 추출
-  const requestExportPublicKey = useCallback(async () => {
-    const pubKey = await exportPublicKey({
-      address: document.getElementById('address_text').value,
-      password,
-    });
-    setPublicKey(pubKey);
-  }, [password]);
-
   return (
     <div style={{ padding: 16 }}>
-      <Button onClick={onNextPage}>Home</Button>
-      <br />
+      <Button className="mb-3" onClick={onNextPage}>
+        Home
+      </Button>
 
-      <div>니모닉 코드</div>
-      <textarea id="importMnemonicInput" style={{ width: '100%' }} />
+      <textarea
+        id="importMnemonicInput"
+        style={{ width: '100%' }}
+        placeholder="니모닉 구문 입력"
+        onChange={(e) => {
+          setRecoverySeed(e.target.value);
+        }}
+      />
       <TextField
         password
         placeholder="새 비밀번호 입력"
         onChange={(e) => {
-          setPassword(e.target.value);
+          setRecoveryPassword(e.target.value);
         }}
       />
-      <Button onClick={requestImportAccount}>계정 복구</Button>
-      <div>복구 계정 : {JSON.stringify(accountsData)}</div>
+      <Button onClick={handleRecoveryAccount} color={THEME_COLOR.SUCCESS}>
+        계정 복구
+      </Button>
+      {recoveryAccount && (
+        <Card title="복구 계정" content={recoveryAccount[0]} />
+      )}
 
-      <br />
-      <TextField placeholder="주소값 입력" id="address_text" />
-      <Button onClick={requestExportPrivateKey}>privateKey 추출</Button>
-      <div className="break-words">비공개키 : {privateKey}</div>
+      <Card title="Address로 비공개/공개키 추출" />
+      <TextField
+        placeholder="주소값 입력"
+        onChange={(e) => {
+          setAddressToPrivPub(e.target.value);
+        }}
+      />
+      <TextField
+        password
+        placeholder="비밀번호 입력"
+        onChange={(e) => {
+          setPasswordToPrivPub(e.target.value);
+        }}
+      />
+      <Button
+        className="mb-1"
+        onClick={refetchExportPrivKey}
+        color={THEME_COLOR.INFO}
+      >
+        비공개키 추출
+      </Button>
+      <Button onClick={refetchExportPubKey} color={THEME_COLOR.WARNING}>
+        공개키 추출
+      </Button>
+      {exportPrivKey && <Card title="비공개키" content={exportPrivKey} />}
+      {exportPubKey && <Card title="공개키" content={exportPubKey} />}
 
-      <br />
-      <Button onClick={requestExportPublicKey}>publicKey 추출</Button>
-      <div className="break-words">공개키 : {publicKey}</div>
+      <Card title="keystore.json(V3) -> 비공개키 추출" />
+      <FileInput
+        readAs="text"
+        onLoad={(event) => setKeystoreInput(event.target.result)}
+        style={{
+          padding: '20px 0px 12px 15%',
+          fontSize: '15px',
+          display: 'flex',
+          justifyContent: 'center',
+          width: '100%',
+        }}
+      />
+      <TextField
+        password
+        placeholder="keystore 비밀번호 입력"
+        onChange={(e) => {
+          setKeystorePassword(e.target.value);
+        }}
+      />
+      <Button
+        className="mb-1"
+        onClick={refetchKeystoreToPrivKey}
+        color={THEME_COLOR.INFO}
+      >
+        비공개키 추출
+      </Button>
+      {keystoreToPrivKey && (
+        <Card title="비공개키" content={keystoreToPrivKey.privKey} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
1. account background API 호출이 react-query로 안되어 있는 부분 및 UI 리팩토링 진행
2. keystore.json(v3)로 private key를 추출하는 기능 추가

### Short description

_Short description_

### Proposed changes

- _proposed changes_

### How to test (Optional)

_How to test this PR_

### Screenshots (Optional)

#### Before this PR

#### After this PR

### Reference (Optional)

_resolves #issue-number_
_closes #issue-number_
_refs #issue-number_
