### PR TITLE
graphql api 추가

### DIFF
--- a/src/app/background.js
+++ b/src/app/background.js
@@ -178,6 +178,11 @@ class Background {
       BackgroundMessages.GET_ERC721_TRANSFER_HISTORY,
       this.controller.getErc721TransferHistory,
     );
+
+    this.requests.set(
+      BackgroundMessages.GET_KLAYTN_TX_HISTORY,
+      this.controller.getKlaytnTxHistory,
+    );
   }
 
   listenForMessages() {

--- a/src/app/controller.js
+++ b/src/app/controller.js
@@ -105,6 +105,11 @@ class Controller extends EventEmitter {
       HISTORY_EVENTS.TX_LIST_DID_CHANGE,
     );
 
+    this.onKlaytnHistoryChange = this.historyController.on.bind(
+      this.historyController,
+      HISTORY_EVENTS.KLAYTN_TX_LIST_DID_CHANGE,
+    );
+
     this.onEthHistoryChange(async () => {
       try {
         remotePort.postMessage({
@@ -366,6 +371,11 @@ class Controller extends EventEmitter {
   getErc721TransferHistory = () => {
     const { erc721transfers } = this.historyController;
     return Promise.resolve(erc721transfers);
+  };
+
+  getKlaytnTxHistory = () => {
+    const { klaytnTransactions } = this.historyController;
+    return Promise.resolve(klaytnTransactions);
   };
 }
 

--- a/src/app/messages.js
+++ b/src/app/messages.js
@@ -29,4 +29,5 @@ export const BackgroundMessages = {
   GET_ETH_TX_HISTORY: 'getEthTxHistory',
   GET_ERC20_TRANSFER_HISTORY: 'getErc20TransferHistory',
   GET_ERC721_TRANSFER_HISTORY: 'getErc721TransferHistory',
+  GET_KLAYTN_TX_HISTORY: 'getKlaytnTxHistory',
 };

--- a/src/ui/data/history/history.api.js
+++ b/src/ui/data/history/history.api.js
@@ -24,3 +24,11 @@ export async function getErc721TransferHistory() {
   );
   return erc721transfers;
 }
+
+// klaytn 트랜잭션 내역 조회
+export async function getKlaytnTxHistory() {
+  const klaytnTransactions = await Messenger.sendMessageToBackground(
+    BackgroundMessages.GET_KLAYTN_TX_HISTORY,
+  );
+  return klaytnTransactions;
+}

--- a/src/ui/data/history/history.hooks.js
+++ b/src/ui/data/history/history.hooks.js
@@ -5,6 +5,7 @@ import {
   getErc20TransferHistory,
   getErc721TransferHistory,
   getEthTxHistory,
+  getKlaytnTxHistory,
 } from './history.api';
 
 export function useGetEthTxHistory(options) {
@@ -37,4 +38,12 @@ export function useGetErc721TransferHistory(options) {
       ...options,
     },
   );
+}
+
+export function useGetKlaytnTxHistory(options) {
+  return useQuery(['/history/getKlaytnTxHistory'], getKlaytnTxHistory, {
+    retry: false,
+    refetchInterval: SECOND * 10,
+    ...options,
+  });
 }

--- a/src/ui/pages/eth-history.jsx
+++ b/src/ui/pages/eth-history.jsx
@@ -9,7 +9,10 @@ import { useNavigate } from 'react-router-dom';
 import Button from 'ui/components/atoms/button';
 import Card from 'ui/components/atoms/card';
 import { THEME_COLOR } from 'ui/constants/colors';
-import { useGetEthTxHistory } from 'ui/data/history/history.hooks';
+import {
+  useGetEthTxHistory,
+  useGetKlaytnTxHistory,
+} from 'ui/data/history/history.hooks';
 import { useGetCurrentChainId, useSetProviderType } from 'ui/data/provider';
 import { PortStreamContext } from 'ui/store/port';
 
@@ -20,6 +23,7 @@ function EthHistory() {
     useGetCurrentChainId();
   const { data: bgEthTxHistory, refetch: refetchEthTxHistory } =
     useGetEthTxHistory();
+  const { data: klaytnTxHistory } = useGetKlaytnTxHistory();
   const { mutate } = useSetProviderType({
     onSuccess() {
       getCurrentChainId();
@@ -50,6 +54,8 @@ function EthHistory() {
       setEthTxHistory(bgEthTxHistory);
     }
   }, [bgEthTxHistory]);
+
+  console.log('klaytnTxHistory: ', klaytnTxHistory);
 
   return (
     <div className="p-4">


### PR DESCRIPTION


### Short description

bc explorer에 graphql api를 연동할 것을 대비하여 관련 테스트 로직 추가

### Proposed changes

- fetch graphql로 open graphql api 통신하는 로직 추가
- history controller에서 klaytn type 추가하여 baobab 등이 선택됐을 때 동작하도록함

### How to test (Optional)

_How to test this PR_

### Screenshots (Optional)

#### Before this PR

#### After this PR

### Reference (Optional)

_resolves #issue-number_
_closes #issue-number_
_refs #issue-number_
