### PR TITLE
feat: 홈 공통 account view 컴포넌트 추가

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,6 +88,8 @@ module.exports = {
     'jsx-a11y/label-has-associated-control': 'off',
     'no-return-assign': 'off',
     'no-restricted-syntax': 'off',
+    'jsx-a11y/no-noninteractive-tabindex': 'off',
+    'jsx-a11y/no-noninteractive-element-interactions': 'off',
   },
   globals: {
     React: 'writable',

--- a/public/popup.html
+++ b/public/popup.html
@@ -25,7 +25,7 @@
     -->
     <title>TF Wallet</title>
   </head>
-  <body style="width: 360px; height: 600px">
+  <body style="width: 360px; height: 600px; background-color: #05486e">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="popup"></div>
     <!--

--- a/src/ui/components/account-view/account-view.jsx
+++ b/src/ui/components/account-view/account-view.jsx
@@ -1,0 +1,45 @@
+import { useLocation } from 'react-router-dom';
+import {
+  useGetStoreAccounts,
+  useSetStoreSelectedAddress,
+} from 'ui/data/account/account.hooks';
+
+import './account-view.scss';
+import Balance from './balance';
+import DropdownMenu from './dropdown-menu';
+import SelectedAccount from './selected-account';
+
+function AccountView() {
+  const { pathname } = useLocation();
+  const { data: accounts, refetch: updateAccounts } = useGetStoreAccounts();
+  const { mutate: updateSelectedAddress } = useSetStoreSelectedAddress({
+    onSuccess() {
+      updateAccounts();
+    },
+  });
+
+  const handleAccountChange = (selectedAddress) => {
+    updateSelectedAddress(selectedAddress);
+  };
+
+  const selectedEOA = accounts?.identities?.find(
+    ({ address }) => accounts?.selectedAddress === address,
+  );
+
+  return (
+    <article className="account-view">
+      <SelectedAccount selectedEOA={selectedEOA} />
+      <hr className="mb-4" />
+      {pathname === '/home' ? (
+        <DropdownMenu
+          accounts={accounts}
+          handleAccountChange={handleAccountChange}
+        />
+      ) : (
+        <Balance balance={selectedEOA?.balance ?? '0x0'} />
+      )}
+    </article>
+  );
+}
+
+export default AccountView;

--- a/src/ui/components/account-view/account-view.scss
+++ b/src/ui/components/account-view/account-view.scss
@@ -1,0 +1,3 @@
+.account-view {
+  @apply relative;
+}

--- a/src/ui/components/account-view/balance/balance.jsx
+++ b/src/ui/components/account-view/balance/balance.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function Balance({ balance, symbol = 'KLAY' }) {
+  return (
+    <h4 className="flex justify-center text-white text-2xl">
+      {`${parseInt(balance, 16)} ${symbol}`}
+    </h4>
+  );
+}
+
+export default Balance;

--- a/src/ui/components/account-view/balance/index.js
+++ b/src/ui/components/account-view/balance/index.js
@@ -1,0 +1,1 @@
+export { default } from './balance';

--- a/src/ui/components/account-view/dropdown-menu/dropdown-menu.jsx
+++ b/src/ui/components/account-view/dropdown-menu/dropdown-menu.jsx
@@ -1,0 +1,75 @@
+import classNames from 'classnames';
+import { useRef, useState } from 'react';
+import { AiOutlineCheck } from 'react-icons/ai';
+import { GiHamburgerMenu } from 'react-icons/gi';
+import { useNavigate } from 'react-router-dom';
+import { useClickAway } from 'react-use';
+
+import './dropdown-menu.scss';
+
+export default function DropdownMenu({ accounts, handleAccountChange }) {
+  const navigation = useNavigate();
+  const dropdownMenuRef = useRef(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  useClickAway(dropdownMenuRef, () => {
+    setIsOpen(false);
+  });
+
+  const handleMenuOpen = () => {
+    setIsOpen(true);
+  };
+
+  return (
+    <div className="dropdown dropdown-end dropdown-menu">
+      <div className="dropdown-menu__icon" onClick={handleMenuOpen}>
+        <GiHamburgerMenu />
+      </div>
+      <ul
+        ref={dropdownMenuRef}
+        className={classNames('dropdown-menu__contents dropdown-content', {
+          open: isOpen,
+        })}
+      >
+        <li onClick={() => null}>
+          <label htmlFor="dropdown-menu__account__modal">계정 변경</label>
+        </li>
+        <li onClick={() => navigation('/account-import')}>
+          <span>계정 추가</span>
+        </li>
+        <li onClick={() => navigation('/account-export')}>
+          <span>계정 내보내기</span>
+        </li>
+      </ul>
+
+      <input
+        type="checkbox"
+        id="dropdown-menu__account__modal"
+        className="modal-toggle"
+      />
+      <div className="modal">
+        <div className="modal-box">
+          <h3 className="font-bold text-lg text-left">내 계정</h3>
+          <hr className="mt-2 mb-4" />
+          {accounts?.identities.map(({ address, name }) => (
+            <div
+              key={address}
+              className="flex items-center text-lg cursor-pointer"
+              onClick={() => handleAccountChange(address)}
+            >
+              {accounts?.selectedAddress === address ? (
+                <AiOutlineCheck className="mr-2 text-[#51b778]" />
+              ) : null}
+              <label className="cursor-pointer">{name}</label>
+            </div>
+          ))}
+          <div className="modal-action">
+            <label htmlFor="dropdown-menu__account__modal" className="btn">
+              닫기
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/account-view/dropdown-menu/dropdown-menu.scss
+++ b/src/ui/components/account-view/dropdown-menu/dropdown-menu.scss
@@ -1,0 +1,19 @@
+.dropdown-menu {
+  @apply absolute right-0 top-0 #{!important};
+
+  &__icon {
+    @apply inline-block p-4 text-right cursor-pointer;
+
+    & svg {
+      @apply inline w-8 h-8 text-white;
+    }
+  }
+
+  &__contents {
+    @apply menu absolute p-2 shadow bg-base-100 w-[175px] -mt-4 mr-2.5 opacity-0 invisible;
+
+    &.open {
+      @apply opacity-100 visible;
+    }
+  }
+}

--- a/src/ui/components/account-view/dropdown-menu/index.js
+++ b/src/ui/components/account-view/dropdown-menu/index.js
@@ -1,0 +1,1 @@
+export { default } from './dropdown-menu';

--- a/src/ui/components/account-view/index.js
+++ b/src/ui/components/account-view/index.js
@@ -1,0 +1,1 @@
+export { default } from './account-view';

--- a/src/ui/components/account-view/selected-account/index.js
+++ b/src/ui/components/account-view/selected-account/index.js
@@ -1,0 +1,1 @@
+export { default } from './selected-account';

--- a/src/ui/components/account-view/selected-account/selected-account.jsx
+++ b/src/ui/components/account-view/selected-account/selected-account.jsx
@@ -1,0 +1,53 @@
+import { SECOND } from 'app/constants/time';
+import { useMemo } from 'react';
+import { useCopyToClipboard, useToggle } from 'react-use';
+import Toast from 'ui/components/atoms/toast';
+import Tooltip from 'ui/components/atoms/tooltip';
+
+import './selected-account.scss';
+
+function SelectedAccount({ selectedEOA }) {
+  const [{ value, error }, copyToClipboard] = useCopyToClipboard();
+  const [isShow, toggle] = useToggle(false);
+  const ellipsisAddress = useMemo(() => {
+    if (selectedEOA) {
+      const { address } = selectedEOA;
+      const prefix = address.slice(0, 5);
+      const suffix = address.slice(-4);
+      return `${prefix}...${suffix}`;
+    }
+    return '0x0';
+  }, [selectedEOA]);
+
+  const copyAddress = (eoa = '0x0') => {
+    copyToClipboard(eoa);
+    toggle();
+    setTimeout(toggle, SECOND);
+  };
+
+  return (
+    <section className="selected-account">
+      <h1 className="text-2xl">{selectedEOA?.name ?? 'Account 1'}</h1>
+      <Tooltip className="mx-auto" message={selectedEOA?.address ?? '0x0'}>
+        <h4
+          className="selected-account__eoa"
+          onClick={() => copyAddress(selectedEOA?.address)}
+        >
+          {ellipsisAddress}
+        </h4>
+      </Tooltip>
+      {value && (
+        <Toast isShow={isShow} severity="success" contents="copied!!" />
+      )}
+      {error && (
+        <Toast
+          isShow={isShow}
+          severity="error"
+          contents="Unable to copy value!"
+        />
+      )}
+    </section>
+  );
+}
+
+export default SelectedAccount;

--- a/src/ui/components/account-view/selected-account/selected-account.scss
+++ b/src/ui/components/account-view/selected-account/selected-account.scss
@@ -1,0 +1,7 @@
+.selected-account {
+  @apply p-4 text-white text-center;
+
+  &__eoa {
+    @apply border-2 border-solid border-[#7c8dcc] rounded cursor-pointer mt-1 p-1;
+  }
+}

--- a/src/ui/components/atoms/toast/toast.scss
+++ b/src/ui/components/atoms/toast/toast.scss
@@ -1,3 +1,3 @@
 .toast {
-  @apply absolute min-w-max left-1/2 top-3/4 p-3 !-translate-x-1/2 !-translate-y-3/4 opacity-0 animate-toast;
+  @apply absolute min-w-max min-h-max left-1/2 top-3/4 p-3 !-translate-x-1/2 !-translate-y-3/4 opacity-0 animate-toast;
 }

--- a/src/ui/components/atoms/tooltip/tooltip.jsx
+++ b/src/ui/components/atoms/tooltip/tooltip.jsx
@@ -15,10 +15,10 @@ function Tooltip({
   children,
   ...tooltipProps
 }) {
-  const tooltipClassName = classnames('tooltip', className);
-  const tooltipPlacement = `tooltip__message-${placement}`;
+  const tooltipClassName = classnames('atoms__tooltip', className);
+  const tooltipPlacement = `atoms__tooltip__message-${placement}`;
   const tooltipMessageClassName = classnames(
-    'tooltip__message',
+    'atoms__tooltip__message',
     tooltipPlacement,
   );
 

--- a/src/ui/components/atoms/tooltip/tooltip.scss
+++ b/src/ui/components/atoms/tooltip/tooltip.scss
@@ -1,4 +1,4 @@
-.tooltip {
+.atoms__tooltip {
   @apply relative w-fit h-fit;
 
   &:hover &__message,

--- a/src/ui/pages/home.jsx
+++ b/src/ui/pages/home.jsx
@@ -1,4 +1,5 @@
 import { Outlet, useNavigate } from 'react-router-dom';
+import AccountView from 'ui/components/account-view/account-view';
 import Header from 'ui/components/header';
 
 function Home() {
@@ -7,6 +8,7 @@ function Home() {
   return (
     <main className="home">
       <Header />
+      <AccountView />
       <Outlet />
     </main>
   );

--- a/src/ui/pages/intro.jsx
+++ b/src/ui/pages/intro.jsx
@@ -23,7 +23,7 @@ function Intro() {
   }, [isLoading, accounts]);
 
   return (
-    <main className="flex flex-col items-center h-screen p-5 bg-[#05486E]">
+    <main className="flex flex-col items-center h-screen p-5">
       <section>
         <Mascot />
       </section>

--- a/src/ui/pages/routing.jsx
+++ b/src/ui/pages/routing.jsx
@@ -37,7 +37,9 @@ function Routing() {
         <Route path="welcome-success" element={<WelcomeSuccess />} />
         <Route path="unlock" element={<Unlock />} />
       </Route>
-      <Route path="/home" element={<Home />} />
+      <Route path="/home" element={<Home />}>
+        {/* <Route index element={<InputAddress />} /> */}
+      </Route>
       <Route path="/provider" element={<Provider />} />
       <Route path="/transaction" element={<Transaction />}>
         <Route index element={<InputAddress />} />


### PR DESCRIPTION
### Short description

홈화면 상단에 address 및 계정추가/변경/내보내기 기능이 있는 컴포넌트 추가

### Proposed changes

AccountView
|
|- SelectedAccount
|- DropdownMenu ( if pathname === '/home' )
|- Balance

### How to test (Optional)

_How to test this PR_

### Screenshots (Optional)

#### Before this PR

#### After this PR

### Reference (Optional)

close #82
